### PR TITLE
Fix browser AudioContext resume on Chrome and other browsers

### DIFF
--- a/src/drawStage.js
+++ b/src/drawStage.js
@@ -40,6 +40,7 @@ export default context => {
 
   if (stage.code === STAGE_TITLE && pressingKeys[32]) {
     stage.startTime = Date.now();
+    window.audioContext.resume();
     stage.code = STAGE_GAME;
   } else if (
     stage.code === STAGE_GAME &&

--- a/src/updateSound.js
+++ b/src/updateSound.js
@@ -4,6 +4,8 @@ import { getDistanceToPlanetSurface, isNearStaelliteStation } from './utils';
 
 window.AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioContext = new AudioContext();
+// AudioContext must be resumed after the document received a user gesture to enable audio playback.
+window.audioContext = audioContext;
 
 const whiteNoise = audioContext.createBufferSource();
 whiteNoise.buffer = noise();


### PR DESCRIPTION
I was getting an error in chrome when playing PlanetFall:
```
(index):7 The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page. https://goo.gl/7K7WLu
```
- https://goo.gl/7K7WLu

Fixed it by ensuring `window.AudioContext.resume()` is called after user has interacted.